### PR TITLE
Hunter's Feign death resets buff timers / Paladin Blessing timers reset - combat log range

### DIFF
--- a/classAbilities.lua
+++ b/classAbilities.lua
@@ -600,23 +600,23 @@ Spell({ 7294, 10298, 10299, 10300, 10301 }, { duration = INFINITY, type = "BUFF"
 
 Spell( 25780, { duration = 1800, type = "BUFF" }) -- Righteous Fury
 
-Spell({ 19740, 19834, 19835, 19836, 19837, 19838, 25291 }, { duration = 300, type = "BUFF" }) -- Blessing of Might
-Spell({ 25782, 25916 }, { duration = 900, type = "BUFF" }) -- Greater Blessing of Might
+Spell({ 19740, 19834, 19835, 19836, 19837, 19838, 25291 }, { duration = 300, type = "BUFF", castFilter = true}) -- Blessing of Might
+Spell({ 25782, 25916 }, { duration = 900, type = "BUFF", castFilter = true}) -- Greater Blessing of Might
 
-Spell({ 19742, 19850, 19852, 19853, 19854, 25290 }, { duration = 300, type = "BUFF" }) -- Blessing of Wisdom
-Spell({ 25894, 25918 }, { duration = 900, type = "BUFF" }) -- Greater Blessing of Might
+Spell({ 19742, 19850, 19852, 19853, 19854, 25290 }, { duration = 300, type = "BUFF", castFilter = true}) -- Blessing of Wisdom
+Spell({ 25894, 25918 }, { duration = 900, type = "BUFF", castFilter = true}) -- Greater Blessing of Might
 
-Spell(20217, { duration = 300, type = "BUFF" }) -- Blessing of Kings
-Spell(25898, { duration = 900, type = "BUFF" }) -- Greater Blessing of Kings
+Spell(20217, { duration = 300, type = "BUFF", castFilter = true}) -- Blessing of Kings
+Spell(25898, { duration = 900, type = "BUFF", castFilter = true}) -- Greater Blessing of Kings
 
-Spell({ 20911, 20912, 20913 }, { duration = 300, type = "BUFF" }) -- Blessing of Sanctuary
-Spell(25899, { duration = 900, type = "BUFF" }) -- Greater Blessing of Sanctuary
+Spell({ 20911, 20912, 20913 }, { duration = 300, type = "BUFF", castFilter = true}) -- Blessing of Sanctuary
+Spell(25899, { duration = 900, type = "BUFF", castFilter = true}) -- Greater Blessing of Sanctuary
 
-Spell(1038, { duration = 300, type = "BUFF" }) -- Blessing of Salvation
-Spell(25895, { duration = 900, type = "BUFF" }) -- Greater Blessing of Salvation
+Spell(1038, { duration = 300, type = "BUFF", castFilter = true}) -- Blessing of Salvation
+Spell(25895, { duration = 900, type = "BUFF", castFilter = true}) -- Greater Blessing of Salvation
 
-Spell({ 19977, 19978, 19979 }, { duration = 300, type = "BUFF" }) -- Blessing of Light
-Spell(25890, { duration = 900, type = "BUFF" }) -- Greater Blessing of Light
+Spell({ 19977, 19978, 19979 }, { duration = 300, type = "BUFF", castFilter = true}) -- Blessing of Light
+Spell(25890, { duration = 900, type = "BUFF", castFilter = true}) -- Greater Blessing of Light
 
 Spell( 20066, { duration = 6 }) -- Repentance
 Spell({ 2878, 5627, 5627 }, {

--- a/core.lua
+++ b/core.lua
@@ -566,15 +566,35 @@ function f:COMBAT_LOG_EVENT_UNFILTERED(event)
         end
     end
     if eventType == "UNIT_DIED" then
-        guids[dstGUID] = nil
-        buffCache[dstGUID] = nil
-        buffCacheValid[dstGUID] = nil
-        guidAccessTimes[dstGUID] = nil
-        local isDstFriendly = bit_band(dstFlags, COMBATLOG_OBJECT_REACTION_FRIENDLY) > 0
-        if enableEnemyBuffTracking and not isDstFriendly then
-            FireToUnits("UNIT_BUFF", dstGUID)
+        local _, englishClass, _, _, _, _, playerName = GetPlayerInfoByGUID(dstGUID)
+        local isFeign = false
+        if englishClass == "HUNTER" then
+            if GetNumGroupMembers() < 6 then
+                for i = 1, MAX_PARTY_MEMBERS do
+                    local unitID = "party"..i
+                    if (UnitName(unitID) == playerName) and (UnitIsFeignDeath(unitID) or (UnitAura("player", "Feign Death") ~= nil)) then
+                        isFeign = true
+                    end
+                end
+            else
+                for i = 1, MAX_RAID_MEMBERS do
+                    local unitID = "raid"..i
+                    if (UnitName(unitID) == playerName) and (UnitIsFeignDeath(unitID) or (UnitAura("player", "Feign Death") ~= nil)) then
+                        isFeign = true
+                    end
+                end
+            end
+        elseif isFeign == false then
+            guids[dstGUID] = nil
+            buffCache[dstGUID] = nil
+            buffCacheValid[dstGUID] = nil
+            guidAccessTimes[dstGUID] = nil
+            local isDstFriendly = bit_band(dstFlags, COMBATLOG_OBJECT_REACTION_FRIENDLY) > 0
+            if enableEnemyBuffTracking and not isDstFriendly then
+                FireToUnits("UNIT_BUFF", dstGUID)
+            end
+            nameplateUnitMap[dstGUID] = nil
         end
-        nameplateUnitMap[dstGUID] = nil
     end
 end
 


### PR DESCRIPTION
[core.lua] --> Updated UNIT_DIED event to check if Party/Raid Hunter(s) cast Feign Death or in fact died. The only reliable method to use is Blizzards API UnitIsFeignDeath() which requires a UnitID and since the Combat Log API's only return GUID's this is impossible unless the Hunter being checked is in a Party or Raid with an addon user. If the Hunter is FD it returns true and bypasses the buffCache clears keeping the timers intact. If the Hunter dies then it returns false and clears the buffCache/timers as normal.

[classAbilities.lua] --> Updated Paladin Blessings to include a castFilter. Players who go out of Combat Log range then return will cause Paladin Blessing timers to reset to max duration. Adding a castFilter will prevent this reset.