### PR TITLE
Store activeFrames in lib table

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -873,7 +873,8 @@ function lib:GetDurationForRank(spellName, spellID, srcGUID)
     end
 end
 
-local activeFrames = {}
+lib.activeFrames = lib.activeFrames or {}
+local activeFrames = lib.activeFrames
 function lib:RegisterFrame(frame)
     activeFrames[frame] = true
     if next(activeFrames) then


### PR DESCRIPTION
Fixes earlier revisions forgetting what addons are registered when a new revision is loaded.
This issue would cause older registered addons to stop working if a newer one unregistered itself.