### PR TITLE
Update core.lua

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -205,45 +205,42 @@ lib.purgeTicker = C_Timer.NewTicker( PURGE_INTERVAL, purgeOldGUIDs)
 -- Restore data if using standalone
 f:RegisterEvent("PLAYER_LOGIN")
 function f:PLAYER_LOGIN()
-    if IsAddOnLoaded("LibClassicDurations") then
-        local function MergeTable(t1, t2)
-            if not t2 then return false end
-            for k,v in pairs(t2) do
-                if type(v) == "table" then
-                    if t1[k] == nil then
-                        t1[k] = CopyTable(v)
-                    else
-                        MergeTable(t1[k], v)
-                    end
-                -- elseif v == "__REMOVED__" then
-                    -- t1[k] = nil
+    local function MergeTable(t1, t2)
+        if not t2 then return false end
+        for k,v in pairs(t2) do
+            if type(v) == "table" then
+                if t1[k] == nil then
+                    t1[k] = CopyTable(v)
                 else
-                    t1[k] = v
+                    MergeTable(t1[k], v)
                 end
+            -- elseif v == "__REMOVED__" then
+                -- t1[k] = nil
+            else
+                t1[k] = v
             end
-            return t1
         end
+        return t1
+    end
 
-        if LCD_Data and LCD_GUIDAccess then
-            local curSessionData = lib.guids
-            lib.guids = LCD_Data
-            guids = lib.guids -- update upvalue
-            MergeTable(guids, curSessionData)
+    if LCD_Data and LCD_GUIDAccess then
+        local curSessionData = lib.guids
+        lib.guids = LCD_Data
+        guids = lib.guids -- update upvalue
+        MergeTable(guids, curSessionData)
 
-            local curSessionAccessTimes = lib.guidAccessTimes
-            lib.guidAccessTimes = LCD_GUIDAccess
-            guidAccessTimes = lib.guidAccessTimes -- update upvalue
-            MergeTable(guidAccessTimes, curSessionAccessTimes)
-        end
+        local curSessionAccessTimes = lib.guidAccessTimes
+        lib.guidAccessTimes = LCD_GUIDAccess
+        guidAccessTimes = lib.guidAccessTimes -- update upvalue
+        MergeTable(guidAccessTimes, curSessionAccessTimes)
+    end
 
-        f:RegisterEvent("PLAYER_LOGOUT")
-        function f:PLAYER_LOGOUT()
-            LCD_Data = guids
-            LCD_GUIDAccess = guidAccessTimes
-        end
+    f:RegisterEvent("PLAYER_LOGOUT")
+    function f:PLAYER_LOGOUT()
+        LCD_Data = guids
+        LCD_GUIDAccess = guidAccessTimes
     end
 end
-
 
 --------------------------
 -- DIMINISHING RETURNS


### PR DESCRIPTION
The reason I'm asking for this change is that I'm getting a TON of complaints from users who have to manually install LibClassicDurations. It doesn't appear in the Twitch client and even though I added LibClassicDurations as a Required Dependency in the pkgmeta file, LibClassicDurations isn't included with PallyPower upon download or installation via Twitch.

* If you remove the IsAddonLoaded check then users would have the option to continue embedding vs running this as a stand alone addon. Timers are still hydrated after a Relog, ReloadUI and/or Crash. I simply added the new tables to my addons TOC.

Example:
## SavedVariables: PallyPowerDB, PallyPower_Assignments, PallyPower_NormalAssignments, PallyPower_AuraAssignments, PallyPower_SavedPresets, PallyPower_ChanNames, LCD_Data, LCD_GUIDAccess

And hydration occurs in the addons SV correctly...
![image](https://user-images.githubusercontent.com/17400948/85732915-9c3d8c00-b6b0-11ea-8d62-8157ed981903.png)
